### PR TITLE
[CHAT-979]: Handle deprecated props

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,15 @@ class PersonalDataFilter {
 		// then a simple _.reduce would simply skip over the non-enumerable properties ultimately removing them from the result
 		const propertyNames = Object.getOwnPropertyNames(data);
 		return _.reduce(propertyNames, (result, key) => {
-			const value = data[key];
+			let value;
+
+			try {
+				value = data[key];
+			} catch (err) {
+				// We can't get the value and we should not include it in the result because we can't filter it.
+				return result;
+			}
+
 			if (this._personalDataProperties.indexOf(key.toString().toLowerCase()) >= 0) {
 				result[key] = this._mask;
 			} else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-personal-data-filter",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-personal-data-filter",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "node-personal-data-filter",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# Purpose

Handle deprecated props. Some objects have deprecated props which throw error in their getters (e.g. app.router). We should handle those errors and exclude them from the result.