### PR TITLE
[CHAT-1449]: Use Set to store visited references

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ class PersonalDataFilter {
     }
 
     filter(data) {
-        const result = this._filterRecursively(data, []);
+        const result = this._filterRecursively(data, new Set());
 
         return result;
     }
@@ -55,10 +55,10 @@ class PersonalDataFilter {
         } else if (_.isObject(data)) { // isObject check should always be after the isArray check because isObject returns true for [].
             // if the current reference has already been traversed this means we've reaced a circular reference
             // simply mask it in order to avoid maximum callstack due to endless traversal
-            if (_.find(referencesCache, (obj) => obj === data)) {
+            if (referencesCache.has(data)) {
                 return this._mask;
             } else {
-                referencesCache.push(data)
+                referencesCache.add(data)
                 return this._maskPersonalDataProperties(data, referencesCache);
             }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-personal-data-filter",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-personal-data-filter",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "node-personal-data-filter",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# Purpose

1. Use `Set` instead of `[]` to store visited references to lower the CPU consumption.